### PR TITLE
Fix Command help strings

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[isort]
+multi_line_output = 3
+include_trailing_comma = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Nothing.
+- Updated to stactools 0.2.3 [#3](https://github.com/stactools-packages/worldpop/pull/3)
+- Made the `mypy` configuration more strict [#3](https://github.com/stactools-packages/worldpop/pull/3)
 
 ### Deprecated
 
@@ -20,4 +21,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Nothing.
+- CLI was failing due to improperly formatted help strings [#3](https://github.com/stactools-packages/worldpop/pull/3)

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,21 @@ mypy_path = src
 explicit_package_bases = True
 namespace_packages = True
 
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = False
+disallow_untyped_decorators = False
+disallow_untyped_defs = True
+no_implicit_optional = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True
+
 [mypy-shapely.*]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 packages = find_namespace:
 install_requires =
     requests ~= 2.26.0
-    stactools == 0.2.1
+    stactools == 0.2.3
 
 [options.packages.find]
 where = src

--- a/src/stactools/worldpop/__init__.py
+++ b/src/stactools/worldpop/__init__.py
@@ -1,4 +1,5 @@
 import stactools.core
+from stactools.cli import Registry
 
 from stactools.worldpop.stac import create_collection, create_item
 
@@ -7,7 +8,7 @@ __all__ = ['create_collection', 'create_item']
 stactools.core.use_fsspec()
 
 
-def register_plugin(registry):
+def register_plugin(registry: Registry) -> None:
     from stactools.worldpop import commands
     registry.register_subcommand(commands.create_worldpop_command)
 

--- a/src/stactools/worldpop/commands.py
+++ b/src/stactools/worldpop/commands.py
@@ -26,12 +26,14 @@ def create_worldpop_command(cli: Any) -> Any:
         "populate-collection",
         short_help="Creates STAC collections for WorldPop data.",
     )
-    @click.option("-p",
-                  "--project",
-                  required=False,
-                  help="The WorldPop project to create a STAC for.",
-                  type=click.Choice(list(COLLECTIONS_METADATA.keys())),
-                  default="pop")
+    @click.option(
+        "-p",
+        "--project",
+        required=False,
+        help="The WorldPop project to create a STAC for.",
+        type=click.Choice(list(COLLECTIONS_METADATA.keys())),
+        default="pop",
+    )
     @click.option(
         "-c",
         "--category",
@@ -39,18 +41,21 @@ def create_worldpop_command(cli: Any) -> Any:
         help="The category to create a STAC for within the chosen project.",
         type=click.Choice(
             sum([list(c.keys()) for c in COLLECTIONS_METADATA.values()], [])),
-        default="wpgpunadj")
+        default="wpgpunadj",
+    )
     @click.option(
         "-d",
         "--destination",
         required=True,
         help="The output directory for the STAC Collection json.",
     )
-    @click.option("-k",
-                  "--api_key",
-                  required=False,
-                  help="A WorldPop API key, required for >1000 calls per day.",
-                  default="")
+    @click.option(
+        "-k",
+        "--api-key",
+        required=False,
+        help="A WorldPop API key, required for >1000 calls per day.",
+        default="",
+    )
     def populate_collection_command(project: str, category: str,
                                     destination: str, api_key: str) -> Any:
         """Creates a collection for one WorldPop project/category and populates it with items.
@@ -92,11 +97,13 @@ def create_worldpop_command(cli: Any) -> Any:
         required=True,
         help="The output directory for the STAC collections.",
     )
-    @click.option("-k",
-                  "--api_key",
-                  required=False,
-                  help="A WorldPop API key, required for >1000 calls per day.",
-                  default="")
+    @click.option(
+        "-k",
+        "--api-key",
+        required=False,
+        help="A WorldPop API key, required for >1000 calls per day.",
+        default="",
+    )
     def populate_all_collections_command(destination: str,
                                          api_key: str) -> Any:
         """Creates collections for all WorldPop projects/categories and populates them
@@ -137,12 +144,14 @@ def create_worldpop_command(cli: Any) -> Any:
         "create-collection",
         short_help="Creates one STAC collection for worldpop data (no items).",
     )
-    @click.option("-p",
-                  "--project",
-                  required=False,
-                  help="The WorldPop project to create a STAC for.",
-                  type=click.Choice(list(COLLECTIONS_METADATA.keys())),
-                  default="pop")
+    @click.option(
+        "-p",
+        "--project",
+        required=False,
+        help="The WorldPop project to create a STAC for.",
+        type=click.Choice(list(COLLECTIONS_METADATA.keys())),
+        default="pop",
+    )
     @click.option(
         "-c",
         "--category",
@@ -189,31 +198,37 @@ def create_worldpop_command(cli: Any) -> Any:
         help="The category to create a STAC for within the chosen project.",
         type=click.Choice(
             sum([list(c.keys()) for c in COLLECTIONS_METADATA.values()], [])),
-        default="wpgpunadj")
-    @click.option("-i",
-                  "--iso3",
-                  required=False,
-                  help="The ISO3 of the country to create a STAC Item for.",
-                  default="CHN")
-    @click.option("-y",
-                  "--popyear",
-                  required=False,
-                  help="The year to create the STAC Item for.",
-                  type=click.Choice(
-                      [str(y) for y in range(2000,
-                                             datetime.now().year)]),
-                  default="2020")
+        default="wpgpunadj",
+    )
+    @click.option(
+        "-i",
+        "--iso3",
+        required=False,
+        help="The ISO3 of the country to create a STAC Item for.",
+        default="CHN",
+    )
+    @click.option(
+        "-y",
+        "--popyear",
+        required=False,
+        help="The year to create the STAC Item for.",
+        type=click.Choice([str(y) for y in range(2000,
+                                                 datetime.now().year)]),
+        default="2020",
+    )
     @click.option(
         "-d",
         "--destination",
         required=True,
         help="The output directory for the STAC Item json.",
     )
-    @click.option("-k",
-                  "--api_key",
-                  required=False,
-                  help="A WorldPop API key, required for >1000 calls per day.",
-                  default="")
+    @click.option(
+        "-k",
+        "--api-key",
+        required=False,
+        help="A WorldPop API key, required for >1000 calls per day.",
+        default="",
+    )
     def create_item_command(project: str, category: str, iso3: str,
                             popyear: str, destination: str,
                             api_key: str) -> Any:
@@ -242,14 +257,18 @@ def create_worldpop_command(cli: Any) -> Any:
         "create-cog",
         short_help="Transform Geotiff to Cloud-Optimized Geotiff.",
     )
-    @click.option("-d",
-                  "--destination",
-                  required=True,
-                  help="The output directory for the COG")
-    @click.option("-s",
-                  "--source",
-                  required=True,
-                  help="Path to an input GeoTiff")
+    @click.option(
+        "-d",
+        "--destination",
+        required=True,
+        help="The output directory for the COG",
+    )
+    @click.option(
+        "-s",
+        "--source",
+        required=True,
+        help="Path to an input GeoTiff",
+    )
     def create_cog_command(destination: str, source: str) -> None:
         """Generate a COG from a GeoTiff. The COG will be saved in the desination
         with `_cog.tif` appended to the name.

--- a/src/stactools/worldpop/commands.py
+++ b/src/stactools/worldpop/commands.py
@@ -17,7 +17,7 @@ def create_worldpop_command(cli: Any) -> Any:
     """Creates the WorldPop STAC."""
     @cli.group(
         "worldpop",
-        short_help=("Commands for working with WorldPop data."),
+        short_help="Commands for working with WorldPop data.",
     )
     def worldpop() -> None:
         pass
@@ -84,7 +84,8 @@ def create_worldpop_command(cli: Any) -> Any:
     @worldpop.command(
         "populate-all-collections",
         short_help=(
-            "Creates and populates all STAC collections for worldpop data.", ))
+            "Creates and populates all STAC collections for worldpop data."),
+    )
     @click.option(
         "-d",
         "--destination",
@@ -173,7 +174,8 @@ def create_worldpop_command(cli: Any) -> Any:
     @worldpop.command(
         "create-item",
         short_help=(
-            "Creates one STAC item for a given project, category and year.", ))
+            "Creates one STAC item for a given project, category and year."),
+    )
     @click.option("-p",
                   "--project",
                   required=False,

--- a/src/stactools/worldpop/stac.py
+++ b/src/stactools/worldpop/stac.py
@@ -3,11 +3,20 @@ import os
 from typing import Any, List, Union
 
 import rasterio
-from pystac import (Asset, CatalogType, Collection, Extent, MediaType,
-                    SpatialExtent, TemporalExtent)
+from pystac import (
+    Asset,
+    CatalogType,
+    Collection,
+    Extent,
+    MediaType,
+    SpatialExtent,
+    TemporalExtent,
+)
 from pystac.extensions.item_assets import AssetDefinition, ItemAssetsExtension
-from pystac.extensions.projection import (ProjectionExtension,
-                                          SummariesProjectionExtension)
+from pystac.extensions.projection import (
+    ProjectionExtension,
+    SummariesProjectionExtension,
+)
 from pystac.extensions.raster import RasterBand, RasterExtension
 from pystac.extensions.scientific import ScientificExtension
 from pystac.item import Item
@@ -16,9 +25,15 @@ from pystac.summaries import Summaries
 from pystac.utils import str_to_datetime
 from shapely.geometry import box
 
-from stactools.worldpop.constants import (API_URL, COLLECTIONS_METADATA,
-                                          KEYWORDS, LICENSE, PROVIDERS,
-                                          WORLDPOP_EPSG, WORLDPOP_EXTENT)
+from stactools.worldpop.constants import (
+    API_URL,
+    COLLECTIONS_METADATA,
+    KEYWORDS,
+    LICENSE,
+    PROVIDERS,
+    WORLDPOP_EPSG,
+    WORLDPOP_EXTENT,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/stactools/worldpop/utils.py
+++ b/src/stactools/worldpop/utils.py
@@ -12,17 +12,20 @@ from stactools.worldpop.constants import API_URL
 
 def get_metadata(url: str) -> Dict[str, Any]:
     """Return dictionary from JSON file at given path."""
+    ret_val: Dict[str, Any]
     scheme = urlparse(url).scheme
     if scheme == "http" or scheme == "https":
         response = requests.get(url)
         if response.status_code != 200:
             raise AssertionError(f"API URL not found: {url}")
-        return response.json()
+        ret_val = response.json()
+        return ret_val
     else:
         if not os.path.exists(url):
             raise AssertionError(f"File path not found: {url}")
         with open(url) as f:
-            return json.load(f)
+            ret_val = json.load(f)
+            return ret_val
 
 
 def get_iso3_list(project: str, category: str) -> List[str]:


### PR DESCRIPTION
Using the CLI was failing because the Command help strings were improperly formatted.
Also updating to stactools 0.2.3. and updating the mypy and isort configurations.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
~- [ ] Documentation has been updated to reflect changes, if applicable.~
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
